### PR TITLE
Added script for cross platform python compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ venv/
 __pycache__/
 .praw.ini
 Planning/
+react-front-end/package-lock.json
+react-front-end/node_modules

--- a/react-front-end/package.json
+++ b/react-front-end/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "start-api": "cd ../ && python3 main.py",
+    "start-api": "node run-api.js",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/react-front-end/run-api.js
+++ b/react-front-end/run-api.js
@@ -1,0 +1,26 @@
+const os = require('node:os');
+var exec = require('node:child_process').exec;
+const isWin = os.platform() == 'win32'
+
+// This is so horrible I hate everything
+// FIX: this so its not stupid and does shit properly instead of just this, needs to return Flask's output 
+
+if(isWin) {
+  exec('cd ../ && python main.py',
+      function (error, stdout, stderr) {
+          console.log(stdout);
+          console.log(stderr);
+          if (error !== null) {
+              console.log(error);
+          }
+      });
+} else {
+  exec('cd ../ && python3 main.py',
+      function (error, stdout, stderr) {
+          console.log(stdout);
+          console.log(stderr);
+          if (error !== null) {
+              console.log(error);
+          }
+      });
+}


### PR DESCRIPTION
Added stupid script to fix issue on Windows where you would try to start the api and it would return 'Python not recognized' because 'python3' was hardcoded instead of 'python' or 'python3' based on the platform.

NOTE: fix the dumb way I start the api through the main.py file, specifically the way I use a relative path. Not clean at all.